### PR TITLE
IE-fix: proper hasOwnProperty check in for..in loop

### DIFF
--- a/blazy.js
+++ b/blazy.js
@@ -203,6 +203,9 @@
         var breakpoints = [],
             key, attribute;
         for (key in ele.attributes) {
+            if (!ele.attributes.hasOwnProperty(key)) {
+                continue;
+            }
             attribute = ele.attributes[key];
             //Does the attribute start with data-src-number?
             if (/^data-src-[0-9]/.test(attribute.name)) {


### PR DESCRIPTION
`for..in` loops through object keys should always include a `hasOwnProperty` check!

This seems to fix the failing iframe lazy-loading in liveblogs in IE.
